### PR TITLE
Merge branch 'release/1.0.0' into develop

### DIFF
--- a/.changes/v1.0.0.md
+++ b/.changes/v1.0.0.md
@@ -1,0 +1,21 @@
+## v1.0.0 (2023-02-18)
+
+## Features
+
+- [Astro](https://astro.build) v2, disabled Astro Telemetry.
+- [Astro Compress](https://github.com/astro-community/astro-compress) - Compress output HTML, CSS, JS, image.
+- [Astro PurgeCSS](https://github.com/codiume/orbit/tree/main/packages/astro-purgecss) - Remove unused CSS from build output.
+- Automate releasing new versions using [GitHub Actions](https://github.com/features/actions) and following the [`git-flow`](https://nvie.com/posts/a-successful-git-branching-model/) branching model.
+- Automate [Netlify](https://netlify.com/) deployment, support GitHub deploy environment. [Go to section](#github-deploy-environment).
+
+**Development features**
+
+- Node package manager: [PNPM](https://pnpm.io/).
+- [Conventional commit](https://conventionalcommits.org/).
+- [ESLint](https://eslint.org) - Static code analyzer.
+- [Prettier](https://prettier.io) - Code formatter.
+- [Renovate](https://www.mend.io/free-developer-tools/renovate/) - Automate dependency updates.
+- [changie](https://changie.dev), [git-chglog](https://github.com/git-chglog/git-chglog) - Generate changelog from conventional commits.
+- [taskfile](https://github.com/ansidev/taskfile) - Task files for common tasks.
+
+Full Changelog: [v1.0.0](https://github.com/ansidev/astro-basic-template/commits/v1.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
+
+## v1.0.0 (2023-02-18)
+
+## Features
+
+- [Astro](https://astro.build) v2, disabled Astro Telemetry.
+- [Astro Compress](https://github.com/astro-community/astro-compress) - Compress output HTML, CSS, JS, image.
+- [Astro PurgeCSS](https://github.com/codiume/orbit/tree/main/packages/astro-purgecss) - Remove unused CSS from build output.
+- Automate releasing new versions using [GitHub Actions](https://github.com/features/actions) and following the [`git-flow`](https://nvie.com/posts/a-successful-git-branching-model/) branching model.
+- Automate [Netlify](https://netlify.com/) deployment, support GitHub deploy environment. [Go to section](#github-deploy-environment).
+
+**Development features**
+
+- Node package manager: [PNPM](https://pnpm.io/).
+- [Conventional commit](https://conventionalcommits.org/).
+- [ESLint](https://eslint.org) - Static code analyzer.
+- [Prettier](https://prettier.io) - Code formatter.
+- [Renovate](https://www.mend.io/free-developer-tools/renovate/) - Automate dependency updates.
+- [changie](https://changie.dev), [git-chglog](https://github.com/git-chglog/git-chglog) - Generate changelog from conventional commits.
+- [taskfile](https://github.com/ansidev/taskfile) - Task files for common tasks.
+
+Full Changelog: [v1.0.0](https://github.com/ansidev/astro-basic-template/commits/v1.0.0)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-starter-template",
   "type": "module",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR merges the branch 'release/1.0.0' back into the branch 'develop'.

This ensures that the updates on the branch 'release/1.0.0', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
