### PR TITLE
Merge branch 'release/1.0.1-rc.0' into develop

### DIFF
--- a/.changes/v1.0.1-rc.0.md
+++ b/.changes/v1.0.1-rc.0.md
@@ -1,0 +1,9 @@
+## [v1.0.1-rc.0](https://github.com/ansidev/astro-basic-template/compare/v1.0.0...v1.0.1-rc.0) (2023-02-22)
+
+### Bug Fixes
+
+- **workflow-deploy:** run two different commands for production and preview deployment
+
+- **workflow-deploy:** ignore deleting PR branch if it does not exist to avoid failed jobs
+
+Full Changelog: [v1.0.0...v1.0.1-rc.0](https://github.com/ansidev/astro-basic-template/compare/v1.0.0...v1.0.1-rc.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v1.0.1-rc.0](https://github.com/ansidev/astro-basic-template/compare/v1.0.0...v1.0.1-rc.0) (2023-02-22)
+
+### Bug Fixes
+
+- **workflow-deploy:** run two different commands for production and preview deployment
+
+- **workflow-deploy:** ignore deleting PR branch if it does not exist to avoid failed jobs
+
+Full Changelog: [v1.0.0...v1.0.1-rc.0](https://github.com/ansidev/astro-basic-template/compare/v1.0.0...v1.0.1-rc.0)
+
 ## v1.0.0 (2023-02-18)
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-starter-template",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR merges the branch 'release/1.0.1-rc.0' back into the branch 'develop'.

This ensures that the updates on the branch 'release/1.0.1-rc.0', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
