### PR TITLE
Merge branch 'release/1.0.1' into develop

### DIFF
--- a/.changes/v1.0.1.md
+++ b/.changes/v1.0.1.md
@@ -1,0 +1,19 @@
+## [v1.0.1](https://github.com/ansidev/astro-basic-template/compare/v1.0.1-rc.0...v1.0.1) (2023-02-22)
+
+### Bug Fixes
+
+- Wrong production URL.
+- Ignore deleting PR branch if it does not exist to avoid failed jobs.
+
+### Dependencies
+
+| Package                          | Version                |
+| -------------------------------- | ---------------------- |
+| @typescript-eslint/eslint-plugin | `5.52.0` `->` `5.53.0` |
+| @typescript-eslint/parser        | `5.52.0` `->` `5.53.0` |
+
+### Documentations
+
+- **readme:** add features and update the project structure
+
+Full Changelog: [v1.0.0...v1.0.1](https://github.com/ansidev/astro-basic-template/compare/v1.0.0...v1.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v1.0.1](https://github.com/ansidev/astro-basic-template/compare/v1.0.1-rc.0...v1.0.1) (2023-02-22)
+
+### Bug Fixes
+
+- Wrong production URL.
+- Ignore deleting PR branch if it does not exist to avoid failed jobs.
+
+### Dependencies
+
+| Package                          | Version                |
+| -------------------------------- | ---------------------- |
+| @typescript-eslint/eslint-plugin | `5.52.0` `->` `5.53.0` |
+| @typescript-eslint/parser        | `5.52.0` `->` `5.53.0` |
+
+### Documentations
+
+- **readme:** add features and update the project structure
+
+Full Changelog: [v1.0.0...v1.0.1](https://github.com/ansidev/astro-basic-template/compare/v1.0.0...v1.0.1)
+
 ## [v1.0.1-rc.0](https://github.com/ansidev/astro-basic-template/compare/v1.0.0...v1.0.1-rc.0) (2023-02-22)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is a starter template for the new [Astro](https://astro.build) project whic
 - [Astro PurgeCSS](https://github.com/codiume/orbit/tree/main/packages/astro-purgecss) - Remove unused CSS from build output.
 - Automate releasing new versions using [GitHub Actions](https://github.com/features/actions) and following the [`git-flow`](https://nvie.com/posts/a-successful-git-branching-model/) branching model.
 - Automate [Netlify](https://netlify.com/) deployment, support GitHub deploy environment. [Go to section](#github-deploy-environment).
+- Automate rebasing PR branch via PR comment: `/rebase`, `/autosquash`, `/rebase-autosquash`.
 
 **Development features**
 
@@ -62,11 +63,14 @@ pnpm create astro@latest --template ansidev/astro-basic-template
 
 Inside of your Astro project, you'll see the following folders and files:
 
+<!-- tree -I 'node_modules|dist|.git|.husky|.netlify|.DS_Store' -a ./ -->
+
 ```
 /
 ├── .changes
-│   └── unreleased
-│       └── .gitkeep
+│   ├── unreleased
+│   │   └── .gitkeep
+│   ├── v*.md
 ├── .changie.yaml
 ├── .chglog
 │   ├── CHANGELOG.tpl.md
@@ -80,7 +84,11 @@ Inside of your Astro project, you'll see the following folders and files:
 ├── .github
 │   ├── FUNDING.yaml
 │   └── workflows
-│       └── deploy_to_netlify.yaml
+│       ├── auto_merge_release_hotfix_into_develop.yaml
+│       ├── deploy_to_netlify.yaml
+│       ├── draft_release_hotfix_pr.yaml
+│       ├── rebase.yaml
+│       └── release.yaml
 ├── .gitignore
 ├── .prettierignore
 ├── .prettierrc.cjs
@@ -94,9 +102,11 @@ Inside of your Astro project, you'll see the following folders and files:
 │   ├── extensions.json
 │   ├── launch.json
 │   └── settings.json
+├── CHANGELOG.md
 ├── LICENSE
 ├── README.md
 ├── Taskfile.yaml
+├── astro-basic-template.code-workspace
 ├── astro.config.mjs
 ├── dotenv.config.ts
 ├── eslint.config.cjs

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-starter-template",
   "type": "module",
-  "version": "1.0.1-rc.0",
+  "version": "1.0.1",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR merges the branch 'release/1.0.1' back into the branch 'develop'.

This ensures that the updates on the branch 'release/1.0.1', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
