### PR TITLE
Fix: `task:dep` commands

### DIFF
--- a/.taskfiles/task_dep.yaml
+++ b/.taskfiles/task_dep.yaml
@@ -10,6 +10,7 @@ includes:
   site:
     taskfile: ./task_site.yaml
     internal: true
+    dir: ../
   git:
     taskfile: ./task_git.yaml
     internal: true

--- a/.taskfiles/task_dep.yaml
+++ b/.taskfiles/task_dep.yaml
@@ -23,7 +23,7 @@ tasks:
     desc: Init git branch {{.BRANCH_DEP_PREFIX}}/*
     cmds:
       - git pull {{.GIT_REMOTE}} {{.BRANCH_BASE}}:{{.BRANCH_BASE}}
-      - git switch {{.BRANCH_DEP_PREFIX}}/{{.BRANCH_NAME}} {{.BRANCH_BASE}} 2>/dev/null || git switch -c {{.BRANCH_DEP_PREFIX}}/{{.BRANCH_NAME}} {{.BRANCH_BASE}}
+      - git branch -D {{.BRANCH_DEP_PREFIX}}/{{.BRANCH_NAME}} 2>/dev/null || git switch -c {{.BRANCH_DEP_PREFIX}}/{{.BRANCH_NAME}} {{.BRANCH_BASE}}
     silent: true
 
   update:


### PR DESCRIPTION
- fix: set dir for internal task to avoid wrong working
- fix: delete existing branch before initializing
