### PR TITLE
Merge branch 'release/1.0.2' into develop

### DIFF
--- a/.changes/v1.0.2.md
+++ b/.changes/v1.0.2.md
@@ -1,0 +1,34 @@
+## [v1.0.2](https://github.com/ansidev/astro-basic-template/compare/v1.0.1...v1.0.2) (2023-03-10)
+
+### Bug Fixes
+
+- delete existing branch before initializing
+
+- set dir for internal task to avoid wrong working
+
+- use personal GitHub token instead of the default GITHUB_TOKEN
+
+- task:clean command
+
+- **dep:** remove unused packages
+
+### Features
+
+- **config:** update Renovate base branch config
+
+### Dependencies
+
+| Package                            | Version                    |
+| ---------------------------------- | -------------------------- |
+| `astro`                            | `^2.0.14` `->` `^2.1.2`    |
+| `astro-compress`                   | `^1.1.33` `->` `^1.1.35`   |
+| `astro-purgecss`                   | `^2.0.0` `->` `^2.0.1`     |
+| `@types/node`                      | `^18.14.0` `->` `^18.15.0` |
+| `astro`                            | `^2.0.14` `->` `^2.1.2`    |
+| `astro`                            | `^2.0.14` `->` `^2.1.2`    |
+| `@typescript-eslint/eslint-plugin` | `^5.53.0` `->` `^5.54.1`   |
+| `@typescript-eslint/parser`        | `^5.53.0` `->` `^5.54.1`   |
+| `eslint`                           | `^8.34.0` `->` `^8.35.0`   |
+| `eslint-plugin-astro`              | `^0.23.0` `->` `^0.24.0`   |
+
+Full Changelog: [v1.0.1...v1.0.2](https://github.com/ansidev/astro-basic-template/compare/v1.0.1...v1.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v1.0.2](https://github.com/ansidev/astro-basic-template/compare/v1.0.1...v1.0.2) (2023-03-10)
+
+### Bug Fixes
+
+- delete existing branch before initializing
+
+- set dir for internal task to avoid wrong working
+
+- use personal GitHub token instead of the default GITHUB_TOKEN
+
+- task:clean command
+
+- **dep:** remove unused packages
+
+### Features
+
+- **config:** update Renovate base branch config
+
+### Dependencies
+
+| Package                            | Version                    |
+| ---------------------------------- | -------------------------- |
+| `astro`                            | `^2.0.14` `->` `^2.1.2`    |
+| `astro-compress`                   | `^1.1.33` `->` `^1.1.35`   |
+| `astro-purgecss`                   | `^2.0.0` `->` `^2.0.1`     |
+| `@types/node`                      | `^18.14.0` `->` `^18.15.0` |
+| `astro`                            | `^2.0.14` `->` `^2.1.2`    |
+| `astro`                            | `^2.0.14` `->` `^2.1.2`    |
+| `@typescript-eslint/eslint-plugin` | `^5.53.0` `->` `^5.54.1`   |
+| `@typescript-eslint/parser`        | `^5.53.0` `->` `^5.54.1`   |
+| `eslint`                           | `^8.34.0` `->` `^8.35.0`   |
+| `eslint-plugin-astro`              | `^0.23.0` `->` `^0.24.0`   |
+
+Full Changelog: [v1.0.1...v1.0.2](https://github.com/ansidev/astro-basic-template/compare/v1.0.1...v1.0.2)
+
 ## [v1.0.1](https://github.com/ansidev/astro-basic-template/compare/v1.0.1-rc.0...v1.0.1) (2023-02-22)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-starter-template",
   "type": "module",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR merges the branch 'release/1.0.2' back into the branch 'develop'.

This ensures that the updates on the branch 'release/1.0.2', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
