### PR TITLE
Merge branch 'release/1.0.3' into develop

### DIFF
--- a/.changes/v1.0.3.md
+++ b/.changes/v1.0.3.md
@@ -1,0 +1,26 @@
+## [v1.0.3](https://github.com/ansidev/astro-basic-template/compare/v1.0.2...v1.0.3) (2023-03-23)
+
+### Bug Fixes
+
+- **taskfile:** check if branch exists before deleting
+
+- **taskfile:** disable silent mode
+
+### Features
+
+- **renovate:** change renovate update dependency strategy
+
+### Dependencies
+
+| Package                            | Version                    |
+| ---------------------------------- | -------------------------- |
+| `astro`                            | `^2.1.2` `->` `^2.1.5`     |
+| `@commitlint/cli`                  | `^17.4.4` `->` `^17.5.0`   |
+| `@types/node`                      | `^18.15.0` `->` `^18.15.5` |
+| `@typescript-eslint/eslint-plugin` | `^5.54.1` `->` `^5.56.0`   |
+| `@typescript-eslint/parser`        | `^5.54.1` `->` `^5.56.0`   |
+| `eslint`                           | `^8.35.0` `->` `^8.35.0`   |
+| `eslint-plugin-astro`              | `^0.24.0` `->` `^0.26.1`   |
+| `typescript`                       | `^4.9.5` `->` `^5.0.2`     |
+
+Full Changelog: [v1.0.2...v1.0.3](https://github.com/ansidev/astro-basic-template/compare/v1.0.2...v1.0.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v1.0.3](https://github.com/ansidev/astro-basic-template/compare/v1.0.2...v1.0.3) (2023-03-23)
+
+### Bug Fixes
+
+- **taskfile:** check if branch exists before deleting
+
+- **taskfile:** disable silent mode
+
+### Features
+
+- **renovate:** change renovate update dependency strategy
+
+### Dependencies
+
+| Package                            | Version                    |
+| ---------------------------------- | -------------------------- |
+| `astro`                            | `^2.1.2` `->` `^2.1.5`     |
+| `@commitlint/cli`                  | `^17.4.4` `->` `^17.5.0`   |
+| `@types/node`                      | `^18.15.0` `->` `^18.15.5` |
+| `@typescript-eslint/eslint-plugin` | `^5.54.1` `->` `^5.56.0`   |
+| `@typescript-eslint/parser`        | `^5.54.1` `->` `^5.56.0`   |
+| `eslint`                           | `^8.35.0` `->` `^8.35.0`   |
+| `eslint-plugin-astro`              | `^0.24.0` `->` `^0.26.1`   |
+| `typescript`                       | `^4.9.5` `->` `^5.0.2`     |
+
+Full Changelog: [v1.0.2...v1.0.3](https://github.com/ansidev/astro-basic-template/compare/v1.0.2...v1.0.3)
+
 ## [v1.0.2](https://github.com/ansidev/astro-basic-template/compare/v1.0.1...v1.0.2) (2023-03-10)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-starter-template",
   "type": "module",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR merges the branch 'release/1.0.3' back into the branch 'develop'.

This ensures that the updates on the branch 'release/1.0.3', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
