### PR TITLE
Merge branch 'release/1.0.4' into develop

### DIFF
--- a/.changes/v1.0.4.md
+++ b/.changes/v1.0.4.md
@@ -1,0 +1,18 @@
+## [v1.0.4](https://github.com/ansidev/astro-basic-template/compare/v1.0.3...v1.0.4) (2023-03-28)
+
+### Bug Fixes
+
+- **changelog:** correct changelog v1.0.3
+
+- **taskfile:** use snake_case for task name
+
+### Dependencies
+
+| Package                            | Version                     |
+| ---------------------------------- | --------------------------- |
+| `astro`                            | `^2.1.5` `->` `^2.1.7`      |
+| `@types/node`                      | `^18.15.5` `->` `^18.15.10` |
+| `@typescript-eslint/eslint-plugin` | `^5.56.0` `->` `^5.57.0`    |
+| `@typescript-eslint/parser`        | `^5.56.0` `->` `^5.57.0`    |
+
+Full Changelog: [v1.0.3...v1.0.4](https://github.com/ansidev/astro-basic-template/compare/v1.0.3...v1.0.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v1.0.4](https://github.com/ansidev/astro-basic-template/compare/v1.0.3...v1.0.4) (2023-03-28)
+
+### Bug Fixes
+
+- **changelog:** correct changelog v1.0.3
+
+- **taskfile:** use snake_case for task name
+
+### Dependencies
+
+| Package                            | Version                     |
+| ---------------------------------- | --------------------------- |
+| `astro`                            | `^2.1.5` `->` `^2.1.7`      |
+| `@types/node`                      | `^18.15.5` `->` `^18.15.10` |
+| `@typescript-eslint/eslint-plugin` | `^5.56.0` `->` `^5.57.0`    |
+| `@typescript-eslint/parser`        | `^5.56.0` `->` `^5.57.0`    |
+
+Full Changelog: [v1.0.3...v1.0.4](https://github.com/ansidev/astro-basic-template/compare/v1.0.3...v1.0.4)
+
 ## [v1.0.3](https://github.com/ansidev/astro-basic-template/compare/v1.0.2...v1.0.3) (2023-03-23)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # astro-starter-template
 
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/fd1cd0b9-147e-458c-b7d5-13bdfe3f20df/deploy-status)](https://app.netlify.com/sites/astro-basic-template-asd/deploys)
 
 This is a starter template for the new [Astro](https://astro.build) project which is created by [ansidev](https://github.com/ansidev).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-starter-template",
   "type": "module",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR merges the branch 'release/1.0.4' back into the branch 'develop'.

This ensures that the updates on the branch 'release/1.0.4', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
