### PR TITLE
Merge branch 'release/1.0.5' into develop

### DIFF
--- a/.changes/v1.0.5.md
+++ b/.changes/v1.0.5.md
@@ -1,0 +1,9 @@
+## [v1.0.5](https://github.com/ansidev/astro-basic-template/compare/v1.0.4...v1.0.5) (2023-04-20)
+
+### Bug Fixes
+
+- **deps:** update dependency astro-compress to ^1.1.36
+
+- **deps:** update dependency astro to ^2.3.0
+
+Full Changelog: [v1.0.4...v1.0.5](https://github.com/ansidev/astro-basic-template/compare/v1.0.4...v1.0.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v1.0.5](https://github.com/ansidev/astro-basic-template/compare/v1.0.4...v1.0.5) (2023-04-20)
+
+### Bug Fixes
+
+- **deps:** update dependency astro-compress to ^1.1.36
+
+- **deps:** update dependency astro to ^2.3.0
+
+Full Changelog: [v1.0.4...v1.0.5](https://github.com/ansidev/astro-basic-template/compare/v1.0.4...v1.0.5)
+
 ## [v1.0.4](https://github.com/ansidev/astro-basic-template/compare/v1.0.3...v1.0.4) (2023-03-28)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-starter-template",
   "type": "module",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR merges the branch 'release/1.0.5' back into the branch 'develop'.

This ensures that the updates on the branch 'release/1.0.5', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
