### PR TITLE
Merge branch 'release/1.0.6' into develop

### DIFF
--- a/.changes/v1.0.5.md
+++ b/.changes/v1.0.5.md
@@ -1,9 +1,17 @@
 ## [v1.0.5](https://github.com/ansidev/astro-basic-template/compare/v1.0.4...v1.0.5) (2023-04-20)
 
-### Bug Fixes
+### Dependencies
 
-- **deps:** update dependency astro-compress to ^1.1.36
-
-- **deps:** update dependency astro to ^2.3.0
+| Package                            | Version                      |
+| ---------------------------------- | ---------------------------- |
+| `astro`                            | `^2.1.7` `->` `^2.3.0`       |
+| `astro-compress`                   | `^1.1.35` `->` `^1.1.39`     |
+| `@commitlint/cli`                  | `^17.5.0` `->` `^17.6.1`     |
+| `@commitlint/config-conventional`  | `^17.4.4` `->` `^17.6.1`     |
+| `@types/node`                      | `^18.15.10` `->` `^18.15.11` |
+| `@typescript-eslint/eslint-plugin` | `^5.57.0` `->` `^5.59.0`     |
+| `@typescript-eslint/parser`        | `^5.57.0` `->` `^5.59.0`     |
+| `eslint`                           | `^8.36.0` `->` `^8.38.0`     |
+| `typescript`                       | `^5.0.2` `->` `^5.0.4`       |
 
 Full Changelog: [v1.0.4...v1.0.5](https://github.com/ansidev/astro-basic-template/compare/v1.0.4...v1.0.5)

--- a/.changes/v1.0.6.md
+++ b/.changes/v1.0.6.md
@@ -1,0 +1,18 @@
+## [v1.0.6](https://github.com/ansidev/astro-basic-template/compare/v1.0.5...v1.0.6) (2023-05-08)
+
+### Dependencies
+
+| Package                            | Version                     |
+| ---------------------------------- | --------------------------- |
+| `astro`                            | `^2.3.0` `->` `^2.4.2`      |
+| `astro-compress`                   | `^1.1.39` `->` `^1.1.42`    |
+| `@commitlint/cli`                  | `^17.6.1` `->` `^17.6.3`    |
+| `@commitlint/config-conventional`  | `^17.6.1` `->` `^17.6.3`    |
+| `@types/node`                      | `^18.15.11` `->` `^18.16.5` |
+| `@typescript-eslint/eslint-plugin` | `^5.59.0` `->` `^5.59.2`    |
+| `@typescript-eslint/parser`        | `^5.59.0` `->` `^5.59.2`    |
+| `eslint`                           | `^8.38.0` `->` `^8.40.0`    |
+| `eslint-plugin-astro`              | `^0.26.1` `->` `^0.26.2`    |
+
+Full Changelog:
+[v1.0.5...v1.0.6](https://github.com/ansidev/astro-basic-template/compare/v1.0.5...v1.0.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v1.0.6](https://github.com/ansidev/astro-basic-template/compare/v1.0.5...v1.0.6) (2023-05-08)
+
+### Bug Fixes
+
+- **deps:** update dependency astro to ^2.4.2
+
+- **deps:** update dependency astro to ^2.4.0
+
+- **deps:** update dependency astro to ^2.3.4
+
+- **deps:** update dependency astro to ^2.3.2
+
+- **deps:** update dependency astro to ^2.3.1
+
+- **deps:** update dependency astro-compress to ^1.1.42
+
+- **deps:** update dependency astro-compress to ^1.1.41
+
+- **deps:** update dependency astro-compress to ^1.1.40
+
+Full Changelog: [v1.0.5...v1.0.6](https://github.com/ansidev/astro-basic-template/compare/v1.0.5...v1.0.6)
+
 ## [v1.0.5](https://github.com/ansidev/astro-basic-template/compare/v1.0.4...v1.0.5) (2023-04-20)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-starter-template",
   "type": "module",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR merges the branch 'release/1.0.6' back into the branch 'develop'.

This ensures that the updates on the branch 'release/1.0.6', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
