### PR TITLE
Merge branch release/1.0.9 into develop

### DIFF
--- a/.changes/v1.0.9.md
+++ b/.changes/v1.0.9.md
@@ -1,0 +1,16 @@
+## [v1.0.9](https://github.com/ansidev/astro-basic-template/compare/v1.0.8...v1.0.9) (2023-06-13)
+
+### Code Refactoring
+
+- **gihub-workflow:** apply GitHub Actions from ghacts/gitflow
+
+### Dependencies
+
+| Package                            | Version                      |
+| ---------------------------------- | ---------------------------- |
+| `astro`                            | `^2.6.1` `->` `^2.6.3`       |
+| `@types/node`                      | `^18.16.16` `->` `^18.16.18` |
+| `@typescript-eslint/eslint-plugin` | `^5.59.9` `->` `^5.59.11`    |
+| `@typescript-eslint/parser`        | `^5.59.9` `->` `^5.59.11`    |
+
+Full Changelog: [v1.0.8...v1.0.9](https://github.com/ansidev/astro-basic-template/compare/v1.0.8...v1.0.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v1.0.9](https://github.com/ansidev/astro-basic-template/compare/v1.0.8...v1.0.9) (2023-06-13)
+
+### Bug Fixes
+
+- **deps:** update dependency astro to ^2.6.3
+
+- **deps:** update dependency astro to ^2.6.2
+
+### Code Refactoring
+
+- **gihub-workflow:** apply GitHub Actions from ghacts/gitflow
+
+Full Changelog: [v1.0.8...v1.0.9](https://github.com/ansidev/astro-basic-template/compare/v1.0.8...v1.0.9)
+
 ## [v1.0.8](https://github.com/ansidev/astro-basic-template/compare/v1.0.7...v1.0.8) (2023-06-07)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-starter-template",
   "type": "module",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR merges the branch `release/1.0.9` back into the branch `develop`.

This ensures that the updates on the branch `release/1.0.9`, i.e. CHANGELOG and manifest updates, are also present on the branch `develop`.