### PR TITLE
Merge branch release/3.1.0 into develop

### DIFF
--- a/.changes/v3.1.0.md
+++ b/.changes/v3.1.0.md
@@ -1,0 +1,25 @@
+## [v3.1.0](https://github.com/ansidev/astro-basic-template/compare/v3.0.0...v3.1.0) (2024-02-26)
+
+### Bug Fixes
+
+- migrate to new eslint config
+
+- regenerate pnpm-lock.yaml
+
+### Dependencies
+
+| Package                            | Version                         |
+| ---------------------------------- | ------------------------------- |
+| `@astrojs/check`                   | `^0.3.1` `->` `^0.5.0`          |
+| `@typescript-eslint/eslint-plugin` | Replaced by `typescript-eslint` |
+| `@typescript-eslint/parser`        | `^6.12.0` `->` `^7.0.0`         |
+| `eslint`                           | `^8.54.0` `->` `^8.57.0`        |
+| `eslint-plugin-astro`              | `^0.30.0` `->` `^0.31.4`        |
+| `eslint-plugin-simple-import-sort` | `^10.0.0` `->` `^12.0.0`        |
+| `husky`                            | `^8.0.3` `->` `^9.0.0`          |
+| `prettier-plugin-astro`            | `^0.13.0`                       |
+| `typescript`                       | `^5.3.2` `->` `^5.3.3`          |
+| `typescript-eslint`                | `^^7.0.2`                       |
+| `vitest`                           | `^1.0.0` `->` `^1.3.1`          |
+
+Full Changelog: [v3.0.0...v3.1.0](https://github.com/ansidev/astro-basic-template/compare/v3.0.0...v3.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v3.1.0](https://github.com/ansidev/astro-basic-template/compare/v3.0.0...v3.1.0) (2024-02-26)
+
+### Bug Fixes
+
+- migrate to new eslint config
+
+- regenerate pnpm-lock.yaml
+
+### Dependencies
+
+| Package                            | Version                         |
+| ---------------------------------- | ------------------------------- |
+| `@astrojs/check`                   | `^0.3.1` `->` `^0.5.0`          |
+| `@typescript-eslint/eslint-plugin` | Replaced by `typescript-eslint` |
+| `@typescript-eslint/parser`        | `^6.12.0` `->` `^7.0.0`         |
+| `eslint`                           | `^8.54.0` `->` `^8.57.0`        |
+| `eslint-plugin-astro`              | `^0.30.0` `->` `^0.31.4`        |
+| `eslint-plugin-simple-import-sort` | `^10.0.0` `->` `^12.0.0`        |
+| `husky`                            | `^8.0.3` `->` `^9.0.0`          |
+| `prettier-plugin-astro`            | `^0.13.0`                       |
+| `typescript`                       | `^5.3.2` `->` `^5.3.3`          |
+| `typescript-eslint`                | `^^7.0.2`                       |
+| `vitest`                           | `^1.0.0` `->` `^1.3.1`          |
+
+Full Changelog: [v3.0.0...v3.1.0](https://github.com/ansidev/astro-basic-template/compare/v3.0.0...v3.1.0)
+
 ## [v3.0.0](https://github.com/ansidev/astro-basic-template/compare/v2.0.0...v3.0.0) (2023-12-06)
 
 ### Dependencies

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-starter-template",
   "type": "module",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This PR merges the branch `release/3.1.0` back into the branch `develop`.

This ensures that the updates on the branch `release/3.1.0`, i.e. CHANGELOG and manifest updates, are also present on the branch `develop`.